### PR TITLE
Fixed a bug in query.js where multiple filters were not being handled…

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -94,8 +94,7 @@ Query.prototype.encodeQuery = function(query,cb) {
   query = query || {};
 
 
-  Object.keys(query).forEach(function(key) {
-
+Object.keys(query).forEach(function(key) {
     if(!self._schema[key]) {
       encodedQuery.push(key+'='+query[key]);
       return;
@@ -105,19 +104,33 @@ Query.prototype.encodeQuery = function(query,cb) {
     var type = self._schema[key].type || 'string';
 
     if (_.isArray(query[key])) {
+     sails.log.debug("Is array")
       encodedQuery.push(key+'IN'+query[key].join(','));
     }
     else if (_.isObject(query[key])) {
+     sails.log.debug("in QUERY.JS, and key is  : "+ JSON.stringify(key));
+     sails.log.debug("Is Object")
       // Conditions
       var conditionDef = query[key];
       _.each(_.pairs(conditionDef), function(conditionKV) {
+        sails.log.debug("in QUERY.JS, and this is conditionKV : "+ JSON.stringify(conditionKV));
         var condition = conditionMap[conditionKV[0]];
         if (condition) {
-          encodedQuery.push(key+condition+self.encodeValue(conditionKV[1],type));
+          if (_.isArray(conditionKV[1])){
+                var newQuery =[];
+                conditionKV[1].forEach(function(filter) { newQuery.push(key+condition+filter)})
+                var joinedQuery = newQuery.join('^');
+                encodedQuery.push(self.encodeValue(joinedQuery,type));
+          }
+          else {
+                sails.log.debug("in QUERY.JS, and this is being pushed onto encodedQuery  : "+ JSON.stringify(key+condition+self.encodeValue(conditionKV[1],type)));
+                encodedQuery.push(key+condition+self.encodeValue(conditionKV[1],type));
+          }
         }
       });
     }
     else {
+      sails.log.debug("Not sure");
       encodedQuery.push(key+'='+query[key]);
     }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -104,16 +104,12 @@ Object.keys(query).forEach(function(key) {
     var type = self._schema[key].type || 'string';
 
     if (_.isArray(query[key])) {
-     sails.log.debug("Is array")
       encodedQuery.push(key+'IN'+query[key].join(','));
     }
     else if (_.isObject(query[key])) {
-     sails.log.debug("in QUERY.JS, and key is  : "+ JSON.stringify(key));
-     sails.log.debug("Is Object")
       // Conditions
       var conditionDef = query[key];
       _.each(_.pairs(conditionDef), function(conditionKV) {
-        sails.log.debug("in QUERY.JS, and this is conditionKV : "+ JSON.stringify(conditionKV));
         var condition = conditionMap[conditionKV[0]];
         if (condition) {
           if (_.isArray(conditionKV[1])){
@@ -123,14 +119,12 @@ Object.keys(query).forEach(function(key) {
                 encodedQuery.push(self.encodeValue(joinedQuery,type));
           }
           else {
-                sails.log.debug("in QUERY.JS, and this is being pushed onto encodedQuery  : "+ JSON.stringify(key+condition+self.encodeValue(conditionKV[1],type)));
                 encodedQuery.push(key+condition+self.encodeValue(conditionKV[1],type));
           }
         }
       });
     }
     else {
-      sails.log.debug("Not sure");
       encodedQuery.push(key+'='+query[key]);
     }
 


### PR DESCRIPTION
I added some code to better handle multiple filters correctly.  They were being passed as a list into the query, but they should have been boolean ANDs.   So instead of this:
sys_class_name!=sc_req_item,incident
the query now looks like this:
sys_class_name!=sc_req_item^sys_class_name!=incident
